### PR TITLE
Better parsing of sync response, ignore shorts, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # ytrecent
+
 Command line utility for keeping up with YouTube channels.
 
 ## Purpose
+
 `ytrecent` is meant to keep track of channels, like YouTube subscriptions, but
 without the need of a Google account or navigating the website with a web
 browser.
 
+## Installation
+
+Download the `ytr.sh` file, and make it executable `chmod u+x ytr.sh`. Copy
+the script into your PATH, e.g. `cp ytr.sh /usr/local/bin/ytr`.
+
 ## Function
+
 Subscriptions are kept track of by keeping a list of channels in a local file.
 The script checks each listed channel for recent videos and stores their
 metadata to a local cache. These videos can then be listed in order of release
@@ -17,13 +25,15 @@ Videos can also be found by using the search function and then played by
 invoking a video player.
 
 ## Requirements
-* POSIX shell and utilities
-* GNU or BSD `date`
-* `column` utility
-* external downloader/player, for getting and playing videos (web browser or
+
+- POSIX shell and utilities
+- GNU or BSD `date`
+- `column` utility
+- external downloader/player, for getting and playing videos (web browser or
   e.g. `mpv` with `youtube-dl`)
 
 ## Usage
+
     usage: ytr <command> [<args>]
 
     commands:
@@ -35,8 +45,11 @@ invoking a video player.
         help       h  -- show information about ytr and its commands
 
 ## Preview
+
 Add some channels to "subscriptions".
 
+    $ ytr channel add https://www.youtube.com/@mikaliden9967
+    "mikaliden9967" added, id=UCgYVXKpeB1y-aoFEn0wJ5PA
     $ ytr channel add eaterbc
     "Ben Eater" added, id=UCS0N5baNlQWJCUrhCEo8WlA
     $ ytr channel add https://www.youtube.com/channel/UC1_uAIS3r8Vu6JjXWvastJg

--- a/ytr.sh
+++ b/ytr.sh
@@ -70,6 +70,7 @@ FEED_URL_UC="$DOMAIN/feeds/videos.xml?channel_id="
 FEED_URL_PL="$DOMAIN/feeds/videos.xml?playlist_id="
 CHNL_URL="$DOMAIN/channel/"
 USER_URL="$DOMAIN/user/"
+AT_NAME_URL="$DOMAIN/@"
 SEARCH_URL="$DOMAIN/results?search_query="
 # id regex
 CHID_REGEX='UC[a-zA-Z0-9\_-]{22}'
@@ -348,6 +349,12 @@ channel_add_cmd() {
         chid=$(echo "$channel" | cut -d/ -f5)
     elif echo "$channel" | grep -q "$USER_URL"; then
         url="$channel"
+    elif echo "$channel" | grep -q "$AT_NAME_URL"; then
+        chid=$(curl -s "$channel" | grep '/channel/UC' | sed 's_.*/channel/\(UC[^"]*\)".*_\1_g' | head -n 1)
+	url="$DOMAIN"/channel/"$chid"
+	if [ -z "$name" ]; then
+	    name=$(echo "$channel" | cut -d'/' -f4 | awk '{print substr($0, 2)}')
+	fi
     else
         url="$USER_URL$channel"
     fi


### PR DESCRIPTION
Thanks for your tool, I think it will be useful - but I had to make some adaptations, which could be useful to others:

- Adding channels was hard, I found the channelID from the page source, but `ytr add channel UC1a2a3a` resulted in a channel_ids file with some weird html as "name", which lead to errors syncing. To make it easier, I added support to parse the URL that contains the `@name` portion, e.g. you can now `ytr channel add https://www.youtube.com/@mikaliden9967/videos`
- The output of `ytr list` was showing some weird output of some of my videos, some left over html, e.g. `</script><script src=....`. Also some newlines were included for each entry. The AWK parser seems to parse everything more cleanly now.
- ytr was including shorts in the list, I am only interested in full videos, so I filter out entries where the link contains `/shorts`
- The readme didn't explain how to use it, I added a short "installation" section.